### PR TITLE
Adding .opts to this.contentType

### DIFF
--- a/Xhr.js
+++ b/Xhr.js
@@ -95,7 +95,7 @@ class Xhr {
      */
     parseData(data){
         // JSON
-        if(this.contentType=='application/json') return JSON.stringify(data);
+        if(this.opts.contentType=='application/json') return JSON.stringify(data);
         // Query string
         var query = [];
         if(((typeof data).toLowerCase()=='string') || (typeof data).toLowerCase()=='number') {


### PR DESCRIPTION
In parseData, we can see this.contentType being checked for 'application/json'. this.contentType needs to instead be this.opts.contentType to take the opts sent in by the user into consideration.
